### PR TITLE
simplify the Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Windows:
 git clone https://github.com/lethal-bacon0/WebnovelYoinker.git
 cd WebnovelYoinker
 make windows
+```
 And then use the exe file in bin. I guess.
 I have no idea how to use make on windows and didn't test it
-```
 
 #### Currently supported export formats:
   - Epub (epub)

--- a/makefile
+++ b/makefile
@@ -1,32 +1,27 @@
-GOARCH=amd64
-GOARM=5
+PREFIX =	/usr
+DESTDIR =
 
-ifeq ($(OS),Windows_NT)
-    uname_S := Windows
-	GOOS=windows
-endif
-ifeq ($(OS),Linux)
-    uname_S := $(shell uname -s)
-	GOOS=linux
-endif
+.PHONY: all clean build linux windows install deinstall
 
-build: clean
+all: clean build
+
+bin/goyoinker:
 	go build -o bin/goyoinker cmd/terminal/goyoinker.go
+
+build: bin/goyoinker
+
 clean:
 	rm -rf bin
 
-all: clean linux windows
-
 linux:
-	GOOS=linux
-	go build -o bin/linux/goyoinker cmd/terminal/goyoinker.go
+	env GOOS=linux go build -o bin/linux/goyoinker cmd/terminal/goyoinker.go
 
 windows:
-	GOOS=windows
-	go build -o bin/windows/goyoinker.exe cmd/terminal/goyoinker.go
+	env GOOS=windows go build -o bin/windows/goyoinker.exe cmd/terminal/goyoinker.go
 
-install:
-	cp bin/goyoinker /usr/bin
+install: bin/goyoinker
+	mkdir -p ${DESTDIR}${PREFIX}/bin
+	install -m755 bin/goyoinker ${DESTDIR}${PREFIX}/bin/goyoinker
 
-remove: 
-	rm /usr/bin/goyoinker
+uninstall: 
+	rm ${DESTDIR}${PREFIX}/bin/goyoinker


### PR DESCRIPTION
 * don't use GNU make extensions if not needed (ifeq.)

 * remove -> uninstall

 * use/respect ${PREFIX} and ${DESTDIR} in the install/uninstall
   target; it's easier for packagers and the like.

 * use `env GOOS=XXX ...` instead of setting the variable and call the
   program in two step: the variable is no longer set when the `go build`
   command is ran.

 * mark PHONY targets (i.e. those that don't are associated with files)