### PR TITLE
always close net.http response Body

### DIFF
--- a/pkg/yoinker/scrape/crimsonmagicScraper.go
+++ b/pkg/yoinker/scrape/crimsonmagicScraper.go
@@ -23,6 +23,7 @@ func (c *CrimsonmagicNovelScraper) ScrapeChapter(chapterURL string, chapterNumbe
 	if err != nil {
 		return book.Chapter{}
 	}
+	defer resp.Body.Close()
 	root, err := html.Parse(resp.Body)
 	chapter := book.Chapter{
 		ChapterNumber: chapterNumber,
@@ -79,6 +80,7 @@ func (c CrimsonmagicNovelScraper) GetAvailableChapters(url string) []book.Volume
 	if err != nil {
 		return nil
 	}
+	defer response.Body.Close()
 	root, err := html.Parse(response.Body)
 	entryContent, ok := scrape.Find(root, scrape.ByClass("entry-content"))
 	if !ok {

--- a/pkg/yoinker/scrape/wuxiaworldScraper.go
+++ b/pkg/yoinker/scrape/wuxiaworldScraper.go
@@ -31,6 +31,7 @@ func (w *WuxiaWorldScraper) ScrapeChapter(chapterURL string, chapterNumber int) 
 	if err != nil {
 		return book.Chapter{}
 	}
+	defer response.Body.Close()
 	root, err := html.Parse(response.Body)
 	if chapterNameNode, ok := scrape.Find(root, chapterTitleMatcher); ok {
 		chapterName = scrape.Text(chapterNameNode)


### PR DESCRIPTION
Users of `http.Get` should explicitly close `response.Body` once done with it.  Atm it works only because the response object are reaped by the GC.